### PR TITLE
Fixed cutFlow bug related to running code on skims

### DIFF
--- a/skimmer/skim.py
+++ b/skimmer/skim.py
@@ -221,12 +221,10 @@ def main():
     accumulator = skim(input_file_names, args)
 
     # Making output ROOT file
-
+    cut_flow_tree = __prepare_cut_flow_tree(accumulator["cut_flow"].value)
     if args.skim_source:
         # use original values from the skim's cutFlow
-        cut_flow_tree = skimmer_utils.get_cutFlow_from_skims(args.input_files, cut_flow_tree)
-    else:
-        cut_flow_tree = __prepare_cut_flow_tree(accumulator["cut_flow"].value)
+        cut_flow_tree = skimmer_utils.__get_cutFlow_from_skims(args.input_files, cut_flow_tree)
 
     trees = {
         "CutFlow": cut_flow_tree

--- a/skimmer/skim.py
+++ b/skimmer/skim.py
@@ -221,7 +221,13 @@ def main():
     accumulator = skim(input_file_names, args)
 
     # Making output ROOT file
-    cut_flow_tree = __prepare_cut_flow_tree(accumulator["cut_flow"].value)
+
+    if args.skim_source:
+        # use original values from the skim's cutFlow
+        cut_flow_tree = skimmer_utils.get_cutFlow_from_skims(args.input_files, cut_flow_tree)
+    else:
+        cut_flow_tree = __prepare_cut_flow_tree(accumulator["cut_flow"].value)
+
     trees = {
         "CutFlow": cut_flow_tree
     }

--- a/skimmer/skimmer_utils.py
+++ b/skimmer/skimmer_utils.py
@@ -3,6 +3,7 @@ from coffea.nanoevents.methods import vector
 
 from utils.tree_maker.triggers import trigger_table
 from utils.Logger import *
+import uproot
 
 # Needed so that ak.zip({"pt": [...], "eta": [...], "phi": [...], "mass": [...]},
 #                         with_name="PtEtaPhiMLorentzVector")
@@ -93,3 +94,7 @@ def make_pt_eta_phi_mass_lorentz_vector(pt, eta=None, phi=None, mass=None):
 def __get_number_of_events(events):
     return ak.sum(events.Weight)
 
+def get_cutFlow_from_skims(input_file, cut_flow_tree):
+    f = uproot.open(input_file)
+    cut_flow = f["CutFlow"].arrays(cut_flow_tree.keys(),  library="pd")#.head(100)
+    return cut_flow.to_dict()

--- a/skimmer/skimmer_utils.py
+++ b/skimmer/skimmer_utils.py
@@ -94,7 +94,7 @@ def make_pt_eta_phi_mass_lorentz_vector(pt, eta=None, phi=None, mass=None):
 def __get_number_of_events(events):
     return ak.sum(events.Weight)
 
-def get_cutFlow_from_skims(input_file, cut_flow_tree):
+def __get_cutFlow_from_skims(input_file, cut_flow_tree):
     f = uproot.open(input_file)
-    cut_flow = f["CutFlow"].arrays(cut_flow_tree.keys(),  library="pd")#.head(100)
-    return cut_flow.to_dict()
+    cut_flow = f["CutFlow"].arrays(cut_flow_tree.keys(),  library="pd")
+    return cut_flow.to_dict("list")


### PR DESCRIPTION
Before this modification, the bug came from the fact that the initial number of events in each skim is the number of events after the preselection cuts applied to the corresponding ntuples. In other words, when we run the skim on the skims, all the cutFlow numbers are the same, i.e. the number of events after the preselection cuts. 

The modification preserves the original cutFlow calculated on the cuts on the TreeMaker ntuples.