### PR TITLE
Added PN tagger score flag to skim production script

### DIFF
--- a/skimmer/make_skims.sh
+++ b/skimmer/make_skims.sh
@@ -14,7 +14,7 @@ LAST_FILE=6  # Use -1 to skim all input files
 dataset_directory=${HOME}/nobackup/SVJ/store/datasets
 module=analysis_configs.t_channel_pre_selection
 selection_name=t_channel_pre_selection
-year=2018
+year=2016
 # Output directory for nominal samples - no variation of the uncertainties
 output_directory=root://cmseos.fnal.gov//store/user/lpcdarkqcd/tchannel_UL/${year}/Full/PrivateSkims/nominal
 
@@ -139,7 +139,7 @@ make_skims() {
                 local output_file_path=$(echo ${output_file} | cut -d/ -f 4-)
                 xrdfs ${output_redirector} ls ${output_file_path} > /dev/null 2>&1
                 if [ "$?" != "0" ] || [ "${FORCE_RECREATE}" == "1" ]; then
-                    python skim.py -i ${input_files} -o ${output_file_tmp} -p ${module} -y ${year} -e ${EXECUTOR} -n ${N_WORKERS} -c ${CHUNK_SIZE} --memory ${MEMORY} --cores ${CORES}
+                    python skim.py -i ${input_files} -o ${output_file_tmp} -p ${module} -y ${year} -e ${EXECUTOR} -n ${N_WORKERS} -c ${CHUNK_SIZE} --memory ${MEMORY} --cores ${CORES} -pn_tagger
                     xrdcp -f ${output_file_tmp} ${output_file}
                     echo ${output_file} has been saved.
                     rm ${output_file_tmp}


### PR DESCRIPTION
Now, in principle, when we run the make_skims.sh script, it should add the particleNet score to the skims.