### PR TITLE
added jet matching with dark quarks for scouting, added new hostname

### DIFF
--- a/analysis_configs/s_channel_scouting_pre_selection.py
+++ b/analysis_configs/s_channel_scouting_pre_selection.py
@@ -116,6 +116,7 @@ def process(events, cut_flow, year, primary_dataset="", pn_tagger=False, **kwarg
     skimmer_utils.update_cut_flow(cut_flow, "DeltaPhiMin selection", events)
     
     events = sequences.add_analysis_branches(events)
+    events = sequences.add_dark_quark_matching(events)
     events = sequences.remove_collections(events)
 
     return events, cut_flow

--- a/analysis_configs/sequences_s_channel_scouting.py
+++ b/analysis_configs/sequences_s_channel_scouting.py
@@ -150,24 +150,34 @@ def add_analysis_branches(events):
     
     return events
 
+
 def add_dark_quark_matching(events):
-    #performs delta R matching between AK8 jets and dark quarks and saves the indices of the matched jets in a new branch
-    #(uses new functions for now, should check if it also works with the old ones)
+    """
+    performs delta R matching between AK8 jets and dark quarks and saves the indices of the matched jets in a new branch
+    """
 
-    jet_eta = events.FatJet_eta
-    jet_phi = events.FatJet_phi
+    jets = skimmer_utils.make_pt_eta_phi_mass_lorentz_vector(
+        pt=events.FatJet_pt,
+        eta=events.FatJet_eta,
+        phi=events.FatJet_phi,
+        mass=events.FatJet_mass,
+    )
 
-    dark_quark_eta = events.MatrixElementGenParticle_eta
-    dark_quark_phi = events.MatrixElementGenParticle_phi
+    dark_quarks =  skimmer_utils.make_pt_eta_phi_mass_lorentz_vector(
+        pt=events.MatrixElementGenParticle_pt,
+        eta=events.MatrixElementGenParticle_eta,
+        phi=events.MatrixElementGenParticle_phi,
+        mass=events.MatrixElementGenParticle_mass,
+    )
 
     # matching with the first dark quark
-    dR1 = event_vars.delta_r_dark_quark(dark_quark_eta[:,0], dark_quark_phi[:,0], jet_eta[:,:], jet_phi[:,:]) <= 0.8
+    dR1 = jets.delta_r(dark_quarks[:,0]) <= 0.8
     dR1 = ak.values_astype(dR1, int)
     matched_index1 = ak.argmax(dR1, axis=1)
     matched_index1 = ak.where(ak.any(dR1, axis=1), matched_index1, -1)
 
     #matching with the second dark quark 
-    dR2 = event_vars.delta_r_dark_quark(dark_quark_eta[:,1], dark_quark_phi[:,1], jet_eta[:,:], jet_phi[:,:]) <= 0.8
+    dR2 = jets.delta_r(dark_quarks[:,1]) <= 0.8
     dR2 = ak.values_astype(dR2, int)
     matched_index2 = ak.argmax(dR2, axis=1)
     matched_index2 = ak.where(ak.any(dR2, axis=1), matched_index2, -1)
@@ -178,11 +188,9 @@ def add_dark_quark_matching(events):
     matched_indices = matched_indices[matched_indices >= 0]
 
     #add new branch to the events 
-    events["FatJet_matchedIdx"] = matched_indices
+    events["FatJetDarkQuarkJetIdx"] = matched_indices
 
     return events
-
-
 
 
 def remove_collections(events):

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -9,6 +9,8 @@ def get_temporary_directory():
         temporary_directory = f"/uscmst1b_scratch/lpc1/3DayLifetime/{os.environ['USER']}"
     elif "t3ui" in os.environ["HOSTNAME"]:
         temporary_directory = f"/tmp/{os.environ['USER']}"
+    elif "portal1" in os.environ["HOSTNAME"]:
+        temporary_directory = f"/tmp/{os.environ['USER']}"
     else:
         log.critical(f"Unknown hostname {os.environ['HOSTNAME']}")
         exit(1)

--- a/tests/skimmer/skim_pfnano_schannel_scouting.py
+++ b/tests/skimmer/skim_pfnano_schannel_scouting.py
@@ -31,6 +31,8 @@ def test_execution():
         run_particle_net = True
     elif "t3ui" in os.environ["HOSTNAME"]:
         run_particle_net = False
+    else:
+        run_particle_net = False
 
     output_path = helper.get_temporary_directory()
     if not os.path.exists(output_path):

--- a/tests/skimmer/skim_treemaker.py
+++ b/tests/skimmer/skim_treemaker.py
@@ -53,6 +53,8 @@ def test_execution():
         run_particle_net = True
     elif "t3ui" in os.environ["HOSTNAME"]:
         run_particle_net = False
+    else:
+        run_particle_net = False
 
     output_path = helper.get_temporary_directory()
     if not os.path.exists(output_path):

--- a/utils/variables_computation/event_variables.py
+++ b/utils/variables_computation/event_variables.py
@@ -130,6 +130,47 @@ def calculate_delta_phi(
     return delta_phi
 
 
+def delta_phi_dark_quark(phi1, phi2):
+    """
+    Calculate delta phi between two physics objects. 
+    This function can handle both single values and arrays.
+    Used to calculate delta phi between a dark quark and all jets. 
+    (not sure if possible with existing delta phi function)
+    
+    Args:
+        phi1, phi2 (array-like or float): 
+            The two angles for which delta phi is to be calculated.
+            Can be single values or arrays of the same shape.
+    Returns:
+        array-like or float
+    """
+    
+    dphi = phi1 - phi2
+    dphi = np.where(dphi > np.pi, dphi - 2 * np.pi, dphi)
+    dphi = np.where(dphi < -np.pi, dphi + 2 * np.pi, dphi)
+    return abs(dphi)
+
+
+def delta_r_dark_quark(eta1, phi1, eta2, phi2):
+    """
+    Calculate delta R between two physics objects. 
+    Used to calculate delta R between a dark quark and all jets.
+    (not sure if possible with existing function)
+    
+    Args:
+        eta, phi (array-like or float): 
+            eta and phi values of the two objects for which delta R is to be calculated
+            Can be single values or arrays of the same shape.
+    Returns:
+        array-like or float
+    """
+    
+    delta_phi = delta_phi_dark_quark(phi1, phi2)
+    delta_eta = abs(eta1 - eta2)
+    delta_R = np.sqrt(delta_eta**2 + delta_phi**2)
+    return delta_R
+
+
 def calculate_delta_r(
         physics_objects,
         indices=(0, 1),

--- a/utils/variables_computation/event_variables.py
+++ b/utils/variables_computation/event_variables.py
@@ -130,47 +130,6 @@ def calculate_delta_phi(
     return delta_phi
 
 
-def delta_phi_dark_quark(phi1, phi2):
-    """
-    Calculate delta phi between two physics objects. 
-    This function can handle both single values and arrays.
-    Used to calculate delta phi between a dark quark and all jets. 
-    (not sure if possible with existing delta phi function)
-    
-    Args:
-        phi1, phi2 (array-like or float): 
-            The two angles for which delta phi is to be calculated.
-            Can be single values or arrays of the same shape.
-    Returns:
-        array-like or float
-    """
-    
-    dphi = phi1 - phi2
-    dphi = np.where(dphi > np.pi, dphi - 2 * np.pi, dphi)
-    dphi = np.where(dphi < -np.pi, dphi + 2 * np.pi, dphi)
-    return abs(dphi)
-
-
-def delta_r_dark_quark(eta1, phi1, eta2, phi2):
-    """
-    Calculate delta R between two physics objects. 
-    Used to calculate delta R between a dark quark and all jets.
-    (not sure if possible with existing function)
-    
-    Args:
-        eta, phi (array-like or float): 
-            eta and phi values of the two objects for which delta R is to be calculated
-            Can be single values or arrays of the same shape.
-    Returns:
-        array-like or float
-    """
-    
-    delta_phi = delta_phi_dark_quark(phi1, phi2)
-    delta_eta = abs(eta1 - eta2)
-    delta_R = np.sqrt(delta_eta**2 + delta_phi**2)
-    return delta_R
-
-
 def calculate_delta_r(
         physics_objects,
         indices=(0, 1),


### PR DESCRIPTION
added jet matching with dark quarks to allow training on only matched jets
the indices of matched FatJets are saved as a new branch to be used like a mask
also added new hostname to be able to run on KIT systems
the jet matching uses new functions for delta phi and delta R for now, because I was not sure if I could make it work with the old ones (calculating the deltas between first/second dark quark and all of the jets at once to be more efficient instead of using a bunch of for loops)
these new functions might not be necessary, I might try to make it work with the old ones if I find the time